### PR TITLE
Removed Reference to Window & Re-enabled exception logging

### DIFF
--- a/wire.js
+++ b/wire.js
@@ -962,7 +962,7 @@ define(['require', 'wire/base'], function(require, basePlugin) {
 					} catch(e) {
 						// Exceptions cause chained deferreds to reject
 						// TODO: Should this also switch remaining listeners to reject?
-						// console.error(e);
+						if (console && console.error) { console.error(e); }
 						// which = 'reject';
 						ldeferred.reject(e);
 					}


### PR DESCRIPTION
The wire.js file contains a reference to window which caused the
RequireJS build scripts to choke with an undefined reference. By
changing it to 'this' we can still reference the window but keep
the build scripts happy.

If an exception occurred in one of the constructors
it would silently disappear. This made debugging
extremely hard. The exception is now logged to the
console if there is a console.
