### PR TITLE
Made sizzle throw when you specify an index and it's not found

### DIFF
--- a/wire/sizzle.js
+++ b/wire/sizzle.js
@@ -18,9 +18,15 @@ define(['sizzle', 'wire/domReady'], function(sizzle, domReady) {
 
 		domReady(function() {
 			var result = sizzle(name);
-			promise.resolve(typeof refObj.i == 'number' && refObj.i < result.length
-				? result[refObj.i]
-				: result);
+			if (typeof refObj.i == 'number') {
+			  if (refObj.i < result.length) {
+          promise.resolve(result[refObj.i]);
+        } else {
+          promise.reject("Query '" + name + "' returned " + result.length + " items while expecting at least " + (refObj.i + 1));
+        }
+			} else {
+        promise.resolve(result)
+			}
 		});
 
 	}


### PR DESCRIPTION
The problem was that when you specified an index
you would be expecting an actual DOM node to be
returned, but if the index was not found it would
return a jquery object instead of a DOM node.
This would cause code to think a DOM node was
returned and try to access DOM properties that
didn't actually exist.
