### PR TITLE
Null pointer bug in scanPlugin

### DIFF
--- a/wire.js
+++ b/wire.js
@@ -488,7 +488,7 @@
 		}
 
 		function scanPlugin(module, spec) {
-			if (typeof module == 'object' && isFunction(module.wire$plugin)) {
+			if (module && typeof module == 'object' && isFunction(module.wire$plugin)) {
 				var plugin = module.wire$plugin(contextPromise, scopeDestroyed, spec);
 				if (plugin) {
 					addPlugin(plugin.resolvers, resolvers);


### PR DESCRIPTION
typeof null == 'object' evaluates to true so
we get a Null pointer exception. So we check to see if
the variable is null or not before we access it.
