### PR TITLE
Change domReady to use callback instead of plugin

### DIFF
--- a/wire/domReady.js
+++ b/wire/domReady.js
@@ -29,10 +29,8 @@ define(['require'], function(req) {
 	// Try require.ready first
 	return (global.require && global.require.ready) || function (cb) {
 		// If it's not available, assume a domReady! plugin is available
-		req(['domReady!'], function () {
-            // Using domReady! as a plugin will automatically wait for domReady
-            // so we can just call the callback.
-            cb();
+		req(['domReady'], function (ready) {
+		  ready(cb);
 		});
 	};
 


### PR DESCRIPTION
We need to use the callback instead of the plugin
because the plugin is constrained by the loaders
time out. So if the dom takes a while to load
then the loader will think the plugin failed
to load and cause it to time out.
