### PR TITLE
Minor changes to Working with Functions

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -148,7 +148,6 @@ doSomethingElse: {
 },
 
 doSomethingThenSomethingElse: {
-	// compose factory accepts an array of functions
 	compose: 'doSomething | doSomethingElse'
 }
 ```
@@ -169,7 +168,6 @@ doSomethingElse: {
 },
 
 doSomethingThenSomethingElse: {
-	// compose factory accepts an array of functions
 	compose: 'aComponent.doSomething | doSomethingElse'
 }
 ```


### PR DESCRIPTION
Correct minor errors and remove misleading comments.  In my opinion the comments should be replaced by something that better describes the shorthand notation being used.
