### PR TITLE
Fix some of the resolver.reject's to return Error objects

### DIFF
--- a/dojo/dijit.js
+++ b/dojo/dijit.js
@@ -115,7 +115,7 @@ define(['dojo', 'dojo/parser', 'dijit', 'dijit/_Widget', '../lib/WireProxy'], fu
                     }
                 );
             } else {
-                resolver.reject("Not a dijit: " + proxy.path);
+                resolver.reject(new Error("Not a dijit: " + proxy.path));
             }
         }
     };

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -416,13 +416,13 @@ define(function(require) {
 		var parts = name.split('.');
 
 		if(parts.length > 2) {
-			return when.reject('Only 1 "." is allowed in refs: ' + name);
+			return when.reject(new Error('Only 1 "." is allowed in refs: ' + name));
 		}
 
 		return when.reduce(parts, function(scope, segment) {
 			return segment in scope
 				? scope[segment]
-				: when.reject('Cannot resolve ref: ' + name);
+				: when.reject(new Error('Cannot resolve ref: ' + name));
 		}, scope);
 	}
 


### PR DESCRIPTION
There are two more rejects that I did not dare touch, as they seemed to return some objects of unspecified form instead of strings. Namely:

Line 36 in [lib/ComponentFactory.js](lib/ComponentFactory.js)

and

Line 72 in [lib/lifecycle.js](lib/lifecycle.js)

There are also some uses of "sentinel" as a reject reason in [test/node/aop-test.js](test/node/aop-test.js) but since it's in the test it might not matter all that much.
