### PR TITLE
Fix small naming discrepency

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -89,7 +89,7 @@ define({
 	helloWired: {
 
 		create: {
-			module: 'app/HelloWire',
+			module: 'app/HelloWired',
 			args: { $ref: 'dom:first!.hello' }
 		},
 
@@ -146,7 +146,7 @@ define({
 	helloWired: {
 
 		create: {
-			module: 'app/HelloWire',
+			module: 'app/HelloWired',
 			args: { $ref: 'dom:first!.hello' }
 		},
 


### PR DESCRIPTION
The code examples use 'app/HelloWire', while references in text (which were greater and appeared to be the intent) use 'app/HelloWired'.
