### PR TITLE
Exclude bower_components from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@ test/
 support/
 experiments/
 components/
+bower_components/
 .gitignore
 .gitmodules
 .npmignore


### PR DESCRIPTION
`npm install --production wire` results in 28M being placed on disk, 27.5M of that is the bower_components directory. I think it's safe to ignore bower artifacts for the npm dist.
