### PR TITLE
bind factory: create partial function applications with injected arguments

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -49,8 +49,9 @@ are:
 1. `module` - loads a module (AMD or CommonJS, depending on your environment)
 2. `create` - creates objects using a constructor function, regular function, or by using Object.create.
 3. `compose` - composes functions using a declarative syntax
-4. `literal` - wire will not parse the right-hand side, but rather use it verbatim as a component
-5. `wire` - recursively invokes wire on another wire spec
+4. `partial` - creates a partial function application with the supplied arguments
+5. `literal` - wire will not parse the right-hand side, but rather use it verbatim as a component
+6. `wire` - recursively invokes wire on another wire spec
 
 ## Using factories
 
@@ -213,6 +214,23 @@ define('my/app/ModuleWithConstructor', function() {
 Functions are first-class citizens in wire.js.  For example, you can [use them as components](functions.md#functions-as-components).  The compose factory allows you to compose function components and component methods into new functions.
 
 See [Composing Functions](functions.md#composing-functions) for more information on composing new functions with the compose factory.
+
+## partial
+
+The partial factory creates a partial function application with the supplied arguments.
+
+### Syntax
+
+```js
+myComponent: {
+	partial: {
+		fn: { module: 'my/app/ModuleA' },
+
+		// Required: use these args to create a partially applied my/app/ModuleA
+		args: [arg1, arg2, arg3...]
+	}
+}
+```
 
 ## literal
 

--- a/lib/plugin/basePlugin.js
+++ b/lib/plugin/basePlugin.js
@@ -206,6 +206,22 @@ define(function(require) {
 		resolver.resolve(wire.loadModule(componentDef.options));
 	}
 
+	function partialFactory(resolver, componentDef, wire) {
+		var partial, fn, args, appliedFn;
+
+		partial = componentDef.options;
+		fn = wire(partial.fn);
+		args = partial.args ? wire(asArray(partial.args)) : [];
+
+		appliedFn = when.join(fn, args).spread(applyFunction);
+
+		resolver.resolve(appliedFn);
+
+		function applyFunction(fn, args) {
+			return functional.partial.apply(functional, [fn].concat(args));
+		}
+	}
+
 	/**
 	 * Factory that uses an AMD module either directly, or as a
 	 * constructor or plain function to create the resulting item.
@@ -265,6 +281,7 @@ define(function(require) {
 	pluginInstance = {
 		factories: {
 			module: moduleFactory,
+			partial: partialFactory,
 			create: instanceFactory,
 			literal: literalFactory,
 			prototype: protoFactory,

--- a/test/node/lib/plugin/basePlugin-test.js
+++ b/test/node/lib/plugin/basePlugin-test.js
@@ -276,6 +276,99 @@ buster.testCase('lib/plugin/basePlugin', {
 		}
 	},
 
+	'partial factory': {
+		'should apply a single argument': function() {
+			var spy, add;
+
+			spy = this.spy();
+			add = function(x, y) { this(); return x + y; }.bind(spy);
+
+			return createContext({
+				increment: {
+					partial: {
+						fn: add,
+						args: 1
+					}
+				}
+			}).then(
+				function(context) {
+					var result = context.increment(4);
+					assert.calledOnce(spy);
+					assert.equals(result, 5);
+				},
+				fail
+			);
+		},
+
+		'should apply multiple arguments': function() {
+			var spy, add;
+
+			spy = this.spy();
+			add = function(x, y) { this(); return x + y; }.bind(spy);
+
+			return createContext({
+				three: {
+					partial: {
+						fn: add,
+						args: [1, 2]
+					}
+				}
+			}).then(
+				function(context) {
+					var result = context.three();
+					assert.calledOnce(spy);
+					assert.equals(result, 3);
+				},
+				fail
+			);
+		},
+
+		'should wire modules': function() {
+			return createContext({
+				increment: {
+					partial: {
+						fn: { module: '../../fixtures/function' },
+						args: 1
+					}
+				}
+			}).then(
+				function(context) {
+					assert.equals(context.increment(2), 3);
+				},
+				fail
+			);
+		},
+
+		'should wire references': function() {
+			var spy, add;
+
+			spy = this.spy();
+			add = function(x, y) { this(); return x + y; }.bind(spy);
+
+			return createContext({
+				increment: {
+					partial: {
+						fn: add,
+						args: 1
+					}
+				},
+				three: {
+					partial: {
+						fn: { $ref: 'increment' },
+						args: 2
+					}
+				}
+			}).then(
+				function(context) {
+					var result = context.three();
+					assert.calledOnce(spy);
+					assert.equals(result, 3);
+				},
+				fail
+			);
+		}
+	},
+
 	'create factory': {
 		'should call non-constructor functions': function() {
 			var spy = this.spy();


### PR DESCRIPTION
This PR implements the `bind` factory, which takes a module that is a function/constructor and a list of arguments, and creates a component that is a partial application of that function on those arguments.

**Use case**
I'm using a third-party data format parser (`MapParser`) that supports binding constructors to annotated entities in the data. Whenever an bound entity is encountered, the parser instantiates an object by passing entity data to the corresponding constructor.

``` js
function MapScreen(entityTypes) {
  this.parser = new MapParser();
  this.parser.bindTypes(entityTypes);
}

MapScreen.prototype.preload = function() {
  this.map = this.parser.parse(this.assets.mapFile);
};
```

Here, `entityTypes` refers to an object injected by wire:

``` js
mapScreen: {
  create: {
    module: 'screens/map_screen',
    args: { $ref: 'entityTypes' }
  }
},

entityTypes: {
  opponent: {
    bind: {
      module: 'entities/opponent',
      args: { $ref: 'opponentFactory' }
    }
  }
}
```

MapParser expects a unary constructor `function(entity)`, but the constructor requires additional components that must be wired in. Continuing the example above, `entities/opponent.js`:

``` js
function Opponent(opponentFactory, entity) {
  this.model = opponentFactory.create(entity.name);
}
```

In such scenarios, the `bind` factory can be useful.
