### PR TITLE
Use args when creating module from a ref.

### DIFF
--- a/lib/plugin/basePlugin.js
+++ b/lib/plugin/basePlugin.js
@@ -202,6 +202,10 @@ define(function(require) {
 		resolver.resolve(cloned);
 	}
 
+	function getArgs(create, wire) {
+		return create.args ? wire(asArray(create.args)) : [];
+	}
+
 	function moduleFactory(resolver, componentDef, wire) {
 		resolver.resolve(wire.loadModule(componentDef.options));
 	}
@@ -223,9 +227,12 @@ define(function(require) {
 			module = wire.loadModule(create);
 		} else if(wire.resolver.isRef(create)) {
 			module = wire(create);
+			args = getArgs(create, wire);
 		} else if(object.isObject(create) && create.module) {
-			module = wire.loadModule(create.module);
-			args = create.args ? wire(asArray(create.args)) : [];
+			module = wire.resolver.isRef(create.module)
+				? wire(create.module)
+				: wire.loadModule(create.module);
+			args = getArgs(create, wire);
 			isConstructor = create.isConstructor;
 		} else {
 			module = create;

--- a/test/node/lib/plugin/basePlugin-test.js
+++ b/test/node/lib/plugin/basePlugin-test.js
@@ -47,6 +47,15 @@ Thing.prototype = {
 	}
 };
 
+function factory1(v1) {
+	return function(v2) {
+		return {
+			value1: v1,
+			value2: v2
+		};
+	};
+}
+
 buster.testCase('lib/plugin/basePlugin', {
 	'module factory': {
 		'should use module exports value as component': function() {
@@ -71,7 +80,7 @@ buster.testCase('lib/plugin/basePlugin', {
 				}
 			}).then(
 				function(context) {
-					assert.equals(context.test.module, 'fake')
+					assert.equals(context.test.module, 'fake');
 				},
 				fail
 			);
@@ -84,7 +93,7 @@ buster.testCase('lib/plugin/basePlugin', {
 				}
 			}).then(
 				function(context) {
-					assert.equals(context.test.x.$ref, 'fake')
+					assert.equals(context.test.x.$ref, 'fake');
 				},
 				fail
 			);
@@ -450,7 +459,7 @@ buster.testCase('lib/plugin/basePlugin', {
 						assert(Constructor.calledWithNew());
 					},
 					fail
-				)
+				);
 			},
 
 			'should not call prototype-less constructor using new when not specified': function() {
@@ -467,8 +476,36 @@ buster.testCase('lib/plugin/basePlugin', {
 						refute(Constructor.calledWithNew());
 					},
 					fail
-				)
+				);
 			}
+		},
+		'should pass args to referenced module': function() {
+			return createContext({
+				f1: {
+					create: {
+						module: factory1,
+						args: 'one'
+					}
+				},
+				test: {
+					create: {
+						$ref: 'f1',
+						args: 'two'
+					}
+				},
+				test2: {
+					create: {
+						module: { $ref: 'f1' },
+						args: 'three'
+					}
+				}
+			}).then(
+				function(context) {
+					assert.equals(context.test, { value1: 'one', value2: 'two' });
+					assert.equals(context.test2, { value1: 'one', value2: 'three' });
+				},
+				fail
+			);
 		}
 	},
 
@@ -768,7 +805,7 @@ buster.testCase('lib/plugin/basePlugin', {
 						test: function(resolver) {
 							resolver.resolve(spy.apply(null, arguments));
 						}
-					}}
+					}};
 				}
 			};
 


### PR DESCRIPTION
Allow to use args with ref both in shorthand and with module.
Close #169 