### PR TITLE
remove unused variable

### DIFF
--- a/lib/ObjectProxy.js
+++ b/lib/ObjectProxy.js
@@ -11,11 +11,10 @@
 (function(define) { 'use strict';
 define(function(require) {
 
-	var WireProxy, extend, before, meld, advise, superDestroy;
+	var WireProxy, extend, meld, advise, superDestroy;
 
 	WireProxy = require('./WireProxy');
 	extend = require('./object').extend;
-	before = require('./advice').before;
 	meld = require('meld');
 
 	// FIXME: Remove support for meld.add after deprecation period


### PR DESCRIPTION
Variable `before` is not used in lib/ObjectProxy.js and should be removed.