### PR TITLE
feature: add support for named constructors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "4.4"
+  - "5.10"
 branches:
   only:
     - master

--- a/docs/components.md
+++ b/docs/components.md
@@ -166,6 +166,9 @@ myComponent: {
 		// and shave off some cpu cycles (No guessing will be done)
 		// at the cost of being more verbose.
 		isConstructor: true, // or false
+		// Optional: If object is instantiated using a named constructor,
+		// you can specify its name here, so that it will be called.
+		namedConstructor: "create",
 	}
 }
 ```

--- a/lib/plugin/basePlugin.js
+++ b/lib/plugin/basePlugin.js
@@ -219,7 +219,7 @@ define(function(require) {
 	 * @param {function} wire
 	 */
 	function instanceFactory(resolver, componentDef, wire) {
-		var create, args, isConstructor, module, instance;
+		var create, args, isConstructor, module, instance, constructorName;
 
 		create = componentDef.options;
 
@@ -228,12 +228,14 @@ define(function(require) {
 		} else if(wire.resolver.isRef(create)) {
 			module = wire(create);
 			args = getArgs(create, wire);
+			constructorName = create.constructorName;
 		} else if(object.isObject(create) && create.module) {
 			module = wire.resolver.isRef(create.module)
 				? wire(create.module)
 				: wire.loadModule(create.module);
 			args = getArgs(create, wire);
 			isConstructor = create.isConstructor;
+			constructorName = create.constructorName;
 		} else {
 			module = create;
 		}
@@ -246,9 +248,11 @@ define(function(require) {
 		function createInstance(module, args) {
 			// We'll either use the module directly, or we need
 			// to instantiate/invoke it.
-			return typeof module == 'function'
-				? instantiate(module, args, isConstructor)
-				: Object.create(module);
+			return constructorName
+				? module[constructorName].apply(module, args)
+				: typeof module == 'function'
+					? instantiate(module, args, isConstructor)
+					: Object.create(module);
 		}
 	}
 


### PR DESCRIPTION
Adds support for named constructors in "create" factory.

I would love to add tests, but I did not find tests for the "create" factory itself.

This PR also allows "hack" where not-a-module is passed as module. It can be then used as factory. Maybe name of "constructorName" option should reflect this, and be "method" instead? And add "factory" as an alias for "module"?